### PR TITLE
added more security to cowrie Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ A prebuild container image is available from the
 [Docker Hub](https://hub.docker.com/r/nkapu/kippo/).
 
 ```
-docker pull nkapu/kippo
 docker run -d -p 2222:2222 --name kippo nkapu/kippo
 ```
 
-### Building in cloned repository
+### Building in a cloned repository
 
 ```
 git clone https://github.com/ouspg/honeypots.git
@@ -34,7 +33,7 @@ cd honeypots/cowrie
 docker build -t cowrie --rm .
 ```
 
-### Building directly from github
+### Building directly from the GitHub
 
 ```
 docker build -t cowrie --rm https://github.com/ouspg/honeypots.git#:cowrie

--- a/cowrie/Dockerfile
+++ b/cowrie/Dockerfile
@@ -16,13 +16,11 @@ RUN apk -U upgrade && \
       py-ipaddress \
       git && \
     pip install enum34
-RUN adduser -D -s /bin/sh kippo kippo && \
-    git clone -q https://github.com/ouspg/cowrie /home/kippo && \
-    cd /home/kippo && \
-    mv cowrie.cfg.dist cowrie.cfg && \
-    chown -R kippo:kippo /home/kippo
+RUN adduser -D -s /bin/sh cowrie cowrie && \
+    su - cowrie -c "git clone -q https://github.com/ouspg/cowrie && \
+                    cd cowrie && cp cowrie.cfg.dist cowrie.cfg"
 
 EXPOSE 2222
-USER kippo
-WORKDIR /home/kippo
+USER cowrie
+WORKDIR /home/cowrie/cowrie
 CMD ./start.sh


### PR DESCRIPTION
- git clone is no longer done as root
- root no longer does recursive chown
- git clone is no longer done to homedir to
  protect against accidential "dot" control files
